### PR TITLE
Further font mods, attempting to block transitions on all children of <body> during load

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -31,7 +31,7 @@ const currentParentPath = pathName.split('/')[1]
     </button>
     <ul
       id='nav-menu-links'
-      class='nav-links sm:gap-4) absolute top-0 right-0 flex h-[90vh] w-full transform-(--dropdown-menu-closed-transform) flex-col items-center justify-center gap-6 bg-(--color-secondary) transition-(--dropdown-menu-closed-transition) duration-500 ease-in sm:visible sm:relative sm:h-auto sm:transform-none sm:flex-row sm:justify-end sm:bg-transparent sm:transition-none [&.expanded]:visible [&.expanded]:transform-(--dropdown-menu-expanded-transform) [&.stop-animation]:transition-(--stop-animation)'
+      class='nav-links absolute top-0 right-0 flex h-[90vh] w-full transform-(--dropdown-menu-closed-transform) flex-col items-center justify-center gap-6 bg-(--color-secondary) transition-(--dropdown-menu-closed-transition) duration-500 ease-in sm:visible sm:relative sm:h-auto sm:transform-none sm:flex-row sm:justify-end sm:gap-4 sm:bg-transparent sm:transition-none [&.expanded]:visible [&.expanded]:transform-(--dropdown-menu-expanded-transform) [&.stop-animation]:transition-(--stop-animation)'
     >
       <li class='m-0 list-none p-3 text-2xl sm:p-0 sm:text-lg'>
         <NavLink

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,7 +21,9 @@ const formattedTitleUrl = capitalize(url)
     <meta name='description' content={contentDescription} />
     <title>{`${siteMetaData.siteTitle} | ${formattedTitleUrl}`}</title>
   </head>
-  <body class='flex min-h-screen w-full flex-col bg-(--color-background)'>
+  <body
+    class='preload flex min-h-screen w-full flex-col bg-(--color-background)'
+  >
     <div class='mx-auto flex w-full max-w-(--breakpoint-md) grow flex-col'>
       <Navigation />
       <main class='grid w-full grow grid-cols-12 gap-4'>
@@ -33,3 +35,8 @@ const formattedTitleUrl = capitalize(url)
     </div>
   </body>
 </html>
+<script>
+  window.addEventListener('load', () => {
+    document.body.classList.remove('preload')
+  })
+</script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3,7 +3,7 @@
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
   font-weight: 400;
   src: url('@fontsource/open-sans/files/open-sans-latin-400-normal.woff2')
     format('woff2');
@@ -12,7 +12,7 @@
 @font-face {
   font-family: 'Merriweather';
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
   font-weight: 400;
   src: url('@fontsource/merriweather/files/merriweather-latin-400-normal.woff2')
     format('woff2');
@@ -25,7 +25,7 @@
   ascent-override: 106%;
   descent-override: normal;
   line-gap-override: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @font-face {
@@ -35,7 +35,7 @@
   ascent-override: 89%;
   descent-override: normal;
   line-gap-override: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @theme {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -297,3 +297,9 @@
 .flow-content > * + * {
   margin-top: 1em;
 }
+
+/* Class appended to body to prevent transitions/animations from firing while CSS is loading */
+.preload * {
+  transition: none !important;
+  animation-duration: 0.001s !important;
+}


### PR DESCRIPTION
Font swap optional behavior not ideal, on some un-cached font loads, loading takes long enough that fonts don't swap. Attempting to stop sporadically-firing transition that controls nav menu animation by adding a `preload` class to the `<body>` element and then  removing it when the `load` event fires.