### PR TITLE
Style changes to nav menu, minor style fixes.

### DIFF
--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -19,7 +19,7 @@ const workExperience = await getCollection('workExperience')
       } = experienceItem.data
       return (
         <div class='flow-content mt-8 flex flex-col first:mt-0'>
-          <h2>
+          <h2 class='text-(--color-heading)'>
             <a
               href={siteUrl}
               class='font-normal underline decoration-transparent transition-all duration-300 ease-in-out hover:decoration-[var(--color-taupe)]'

--- a/src/components/MySpotifyData.jsx
+++ b/src/components/MySpotifyData.jsx
@@ -35,7 +35,7 @@ const RecentTracksSkeleton = () => {
         return (
           <div
             key={i}
-            class='background flex animate-pulse flex-row gap-2 overflow-hidden rounded-xs bg-slate-300 no-underline outline-1 outline-slate-400 md:rounded-sm'
+            class='flex animate-pulse flex-row gap-2 overflow-hidden rounded-xs bg-slate-300 no-underline outline-1 outline-slate-400 md:rounded-sm'
           >
             <div class='m-0 aspect-square h-28 w-28 bg-slate-400' />
             <div class='flex w-full flex-col justify-center gap-2'>
@@ -156,12 +156,12 @@ const MySpotifyData = () => {
     <div class='flex flex-col gap-6'>
       <div>
         <div class='mb-2 flex flex-col justify-end border-1 border-slate-900 bg-(--color-heading) p-1 sm:p-2'>
-          <h3 class='mt-[1.5em] flex items-center gap-2 text-neutral-100'>
+          <h2 class='mt-[1.5em] flex items-center gap-2 text-neutral-100'>
             Top Artists
             <div class='inline-block h-6 w-6 text-neutral-100'>
               <SpotifyLogo />
             </div>
-          </h3>
+          </h2>
           <p class='my-0 text-neutral-100'>
             The six artists I've been listening to the most over the past 6
             months:
@@ -202,12 +202,12 @@ const MySpotifyData = () => {
 
       <div>
         <div class='mb-2 flex flex-col justify-end border-1 border-slate-900 bg-(--color-heading) p-1 sm:p-2'>
-          <h3 class='mt-[1.5em] flex items-center gap-2 text-neutral-100'>
+          <h2 class='mt-[1.5em] flex items-center gap-2 text-neutral-100'>
             Recent Tracks
             <div class='h-6 w-6 text-neutral-100'>
               <SpotifyLogo />
             </div>
-          </h3>
+          </h2>
           <p class='my-0 text-neutral-100'>
             My ten(ish) most recently listened-to tracks:
           </p>

--- a/src/components/NavLink.astro
+++ b/src/components/NavLink.astro
@@ -19,6 +19,7 @@ const { linkName, to, currentParentPath } = Astro.props
     font-size: inherit;
     text-decoration: none;
     font-weight: normal;
+    color: var(--color-primary);
   }
 
   a::after {
@@ -28,14 +29,30 @@ const { linkName, to, currentParentPath } = Astro.props
     overflow: hidden;
     user-select: none;
     pointer-events: none;
-    color: var(--color-taupe);
     font-weight: bold;
   }
 
   .active {
     font-weight: bold;
-    color: var(--color-taupe);
+    color: var(--color-primary);
     text-decoration: underline;
-    text-decoration-color: var(--color-taupe);
+    text-decoration-color: var(--color-primary);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
+  }
+
+  @media (width >= 40rem) {
+    a {
+      color: var(--color-taupe);
+    }
+
+    .active {
+      font-weight: bold;
+      color: inherit;
+      text-decoration: underline;
+      text-decoration-color: var(--color-taupe);
+      text-decoration-thickness: 2px;
+      text-underline-offset: 2px;
+    }
   }
 </style>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -10,11 +10,11 @@ const currentParentPath = pathName.split('/')[1]
 ---
 
 <header>
-  <nav class='relative flex items-center justify-between p-4 sm:mb-2 md:mb-4'>
+  <div id='backdrop' class='backdrop'></div>
+  <nav>
     <Logo />
     <button
       id='nav-menu-button'
-      class='hamburger absolute right-0 z-100 mr-4 aspect-square h-8 w-auto cursor-pointer p-0 sm:hidden'
       aria-labelledby='button-label'
       aria-controls='nav-menu-links'
       aria-expanded='false'
@@ -23,42 +23,160 @@ const currentParentPath = pathName.split('/')[1]
       <Icon
         name='ion:menu-outline'
         title='hamburger menu'
-        class='text-primary pointer-events-none h-full w-full'
         aria-hidden='true'
         focusable='false'
       />
       <span id='button-label' hidden>Site Navigation</span>
     </button>
-    <ul
-      id='nav-menu-links'
-      class='nav-links absolute top-0 right-0 flex h-[90vh] w-full transform-(--dropdown-menu-closed-transform) flex-col items-center justify-center gap-6 bg-(--color-secondary) transition-(--dropdown-menu-closed-transition) duration-500 ease-in sm:visible sm:relative sm:h-auto sm:transform-none sm:flex-row sm:justify-end sm:gap-4 sm:bg-transparent sm:transition-none [&.expanded]:visible [&.expanded]:transform-(--dropdown-menu-expanded-transform) [&.stop-animation]:transition-(--stop-animation)'
-    >
-      <li class='m-0 list-none p-3 text-2xl sm:p-0 sm:text-lg'>
-        <NavLink
-          linkName={'Home'}
-          to={'/'}
-          currentParentPath={currentParentPath}
-        />
-      </li>
-      <li class='m-0 list-none p-3 text-2xl sm:p-0 sm:text-lg'>
-        <NavLink
-          linkName={'Blog'}
-          to={'/blog'}
-          currentParentPath={currentParentPath}
-        />
-      </li>
-      <li class='m-0 list-none p-3 text-2xl sm:p-0 sm:text-lg'>
-        <NavLink
-          linkName={'Consumption'}
-          to={'/consumption'}
-          currentParentPath={currentParentPath}
-        />
-      </li>
-    </ul>
+    <div id='nav-links-wrapper'>
+      <div id='nav-menu-links' class='nav-links'>
+        <ul>
+          <li>
+            <NavLink
+              linkName={'Home'}
+              to={'/'}
+              currentParentPath={currentParentPath}
+            />
+          </li>
+          <li>
+            <NavLink
+              linkName={'Blog'}
+              to={'/blog'}
+              currentParentPath={currentParentPath}
+            />
+          </li>
+          <li>
+            <NavLink
+              linkName={'Consumption'}
+              to={'/consumption'}
+              currentParentPath={currentParentPath}
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
   </nav>
-
   <script>
     import '../scripts/nav-menu.js'
     import '../scripts/stop-animation.ts'
   </script>
 </header>
+
+<style>
+  nav {
+    display: flex;
+    position: relative;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+  }
+
+  button {
+    position: absolute;
+    right: 0;
+    z-index: 500;
+    margin-right: calc(var(--spacing) * 4);
+    aspect-ratio: 1/1;
+    height: calc(var(--spacing) * 8);
+    width: auto;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  button svg {
+    color: var(--color-primary);
+    pointer-events: none;
+    height: 100%;
+    width: 100%;
+  }
+
+  #nav-links-wrapper {
+    display: grid;
+    padding: 0;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    transition: grid-template-rows 0.25s ease-in-out;
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    background-color: var(--color-heading);
+  }
+
+  .nav-links {
+    min-height: 0;
+  }
+
+  #nav-links-wrapper.expanded {
+    grid-template-rows: 1fr;
+    backdrop-filter: blur(2px);
+    border-bottom-color: var(--color-secondary);
+    border-bottom-width: calc(var(--spacing) * 1);
+  }
+
+  #nav-links-wrapper ul {
+    height: 50vh;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  #nav-links-wrapper ul li {
+    margin: 0;
+    list-style: none;
+    padding: calc(var(--spacing) * 3);
+    font-size: calc(var(--text-2xl));
+  }
+
+  #backdrop.blur {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    backdrop-filter: blur(1px);
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+
+  @media (width >= 40rem) {
+    nav {
+      margin-bottom: calc(var(--spacing) * 2);
+    }
+
+    button {
+      display: none;
+    }
+
+    #nav-links-wrapper {
+      display: flex;
+      flex-direction: row;
+      background: none;
+      transition: none;
+      position: relative;
+      justify-content: flex-end;
+    }
+
+    #nav-links-wrapper ul {
+      height: auto;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    #nav-links-wrapper ul li {
+      padding: 0;
+      font-size: var(--text-lg);
+    }
+  }
+
+  @media (width >= 48rem) {
+    nav {
+      margin-bottom: calc(var(--spacing) * 4);
+    }
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,10 +33,10 @@ const formattedTitleUrl = capitalize(url)
       </main>
       <Footer />
     </div>
+    <script>
+      window.addEventListener('load', () => {
+        document.body.classList.remove('preload')
+      })
+    </script>
   </body>
 </html>
-<script>
-  window.addEventListener('load', () => {
-    document.body.classList.remove('preload')
-  })
-</script>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -20,9 +20,9 @@ const allPosts = await getCollection('blog')
               class='group border-heading border-1 px-2 py-4 no-underline'
             >
               <li class='flow-content list-none'>
-                <h3 class='mt-0 capitalize underline decoration-transparent transition-all duration-300 ease-in-out group-has-hover:decoration-[var(--color-taupe)]'>
+                <h2 class='mt-0 text-(--color-heading) capitalize underline decoration-transparent transition-all duration-300 ease-in-out group-has-hover:decoration-[var(--color-taupe)]'>
                   {title}
-                </h3>
+                </h2>
                 <time class='italic' datetime={pubDate.toISOString()}>
                   {/* {pubDate.toDateString()} */}
                   {pubDate.toLocaleDateString('en-EN', {
@@ -43,7 +43,13 @@ const allPosts = await getCollection('blog')
         })}
       </ul>
     ) : (
-      <h2>There are no posts</h2>
+      <div class='flow-content border-heading border-1 px-2 py-4'>
+        <h2 class='text-(--color-heading)'>There are no posts just yet...</h2>
+        <p>
+          I'm working on editing a few of the things I have written so far, and
+          hope to have them up shortly. Please check back again soon!
+        </p>
+      </div>
     )
   }
 </Layout>

--- a/src/scripts/nav-menu.js
+++ b/src/scripts/nav-menu.js
@@ -1,30 +1,33 @@
 const navMenuButton = document.getElementById('nav-menu-button')
-const navMenuLinks = document.getElementById('nav-menu-links')
+const backdropElement = document.getElementById('backdrop')
+const navMenuLinks = document.getElementById('nav-links-wrapper')
 
 // Utility Functions
 function blockScroll() {
   document.body.classList.add('block-scroll')
+  backdropElement.classList.add('blur')
   document.documentElement.classList.add('block-scroll')
 }
 
 function unblockScroll() {
   document.body.classList.remove('block-scroll')
+  backdropElement.classList.remove('blur')
   document.documentElement.classList.remove('block-scroll')
 }
 
 function openNavMenu() {
+  navMenuButton.setAttribute('aria-expanded', 'true')
   navMenuLinks.classList.add('expanded')
   blockScroll()
-  navMenuButton.setAttribute('aria-expanded', 'true')
 
   window.addEventListener('click', detectClickOutsideMenu, true)
   window.addEventListener('keydown', detectEscKeyPress, true)
 }
 
 function closeNavMenu() {
+  navMenuButton.setAttribute('aria-expanded', 'false')
   navMenuLinks.classList.remove('expanded')
   unblockScroll()
-  navMenuButton.setAttribute('aria-expanded', 'false')
 
   window.removeEventListener('click', detectClickOutsideMenu, true)
   window.removeEventListener('keydown', detectEscKeyPress, true)
@@ -45,6 +48,8 @@ function detectClickOutsideMenu(event) {
   ) {
     closeNavMenu()
   }
+
+  return null
 }
 
 // Listener for menu button

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -48,18 +48,7 @@
   --color-background: #e5dac7;
   --color-primary: #ba5c12;
   --color-secondary: #00a6fb;
-  --color-muted: #e0e0ce;
-  --color-gray: #3d3d3d;
-  --color-darken: #e0e0ce;
   --color-taupe: #261f17;
-
-  /* Dropdown Menu */
-  --dropdown-menu-closed-transform: translateY(-100%);
-  --dropdown-menu-closed-transition: transform 0.5s ease-in visibility 0.5s
-    ease-in;
-  --dropdown-menu-expanded-transform: translateY(0);
-  /* Stop animation applied to dropdown menu during resize event */
-  --stop-animation: none !important;
 
   /* Experiment with my own type scale */
   /* Small Screens - Major Second (Base layer) */ /* assuming 1rem == 16px */
@@ -301,5 +290,4 @@
 /* Class appended to body to prevent transitions/animations from firing while CSS is loading */
 .preload * {
   transition: none !important;
-  animation-duration: 0.001s !important;
 }


### PR DESCRIPTION
This mainly encompasses changes made to my dropdown navigation component for small screens. 

Moved away from a transform that relied on applying a `translateY(-100%)` to the elements containing the navigation components to make them "appear" off screen — was experiencing an issue where on loads (sporadically) the navigation would flicker out of view. Couldn't really pin down exactly what was going on and some popular fixes didn't seem to work, namely adding a `preload` class to the `<body>` element and using CSS to forcibly disallow transitions until the `load` event has fired for the `<body>` element. New approach uses sort of a hack that transitions `grid-template-rows` between the values `0` and `1`, which is a transition-able property.

A few minor style changes I overlooked earlier are also included.