### PR TITLE
chore: Adding cache control headers to API

### DIFF
--- a/netlify/functions/getSpotifyData.mjs
+++ b/netlify/functions/getSpotifyData.mjs
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import getRecentTracks from './utils/getRecentTracks.mjs'
 import getTopArtists from './utils/getTopArtists.mjs'
+import { CacheHeaders } from 'cdn-cache-control'
 
 // Options for POST request for refreshing auth token
 const refreshTokenOptions = {
@@ -43,6 +44,7 @@ export default async function getSpotifyData(req) {
 
       const getRecentTracksResponse = await getRecentTracks(accessToken)
       const getTopArtistsResponse = await getTopArtists(accessToken)
+      const cacheControlHeaders = new CacheHeaders(undefined, 'netlify')
 
       const successResponse = new Response(
         JSON.stringify({
@@ -52,7 +54,10 @@ export default async function getSpotifyData(req) {
         }),
         {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...cacheControlHeaders,
+          },
         }
       )
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "astro": "^5.0.8",
     "astro-icon": "^1.1.5",
     "axios": "^1.7.9",
+    "cdn-cache-control": "^1.3.1",
     "lodash.capitalize": "^4.2.1",
     "preact": "^10.25.4",
     "tailwindcss": "3.4.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,11 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+cdn-cache-control@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cdn-cache-control/-/cdn-cache-control-1.3.1.tgz#89c0a58c814c6c1dd1a8267fdccddf4749ca7ce3"
+  integrity sha512-2a0TsO1Eef+6uvb6T0am0AB+BQEOzOh7846Nzar4opMQ00nJyaSOVqFQEjh4/E9GV/Sr/IFBXrff/E2afnz61g==
+
 chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"


### PR DESCRIPTION
Adding cache control headers to the netlify function that fetches Spotify data.