### PR TITLE
fix: fixing req opts buffer syntax

### DIFF
--- a/netlify/functions/utils/refreshTokenOptions.mjs
+++ b/netlify/functions/utils/refreshTokenOptions.mjs
@@ -6,7 +6,7 @@ export const refreshTokenOptions = {
     'Content-Type': 'application/x-www-form-urlencoded',
     Authorization:
       'Basic ' +
-      new Buffer.from(
+      Buffer.from(
         process.env.SPOTIFY_CLIENT_ID + ':' + process.env.SPOTIFY_CLIENT_SECRET
       ).toString('base64'),
   },


### PR DESCRIPTION
Erroneously used `new` keyword alongside Buffer. Use of `new` keyword deprecated, `Buffer.from(...)` is correct way to create a new buffer.